### PR TITLE
Enable Quartet quantization

### DIFF
--- a/utils/argparse.py
+++ b/utils/argparse.py
@@ -111,6 +111,7 @@ def parse_args(args):
 
     # Quantization
     parser.add_argument("--quest", default=False,action="store_true")
+    parser.add_argument("--quartet", default=False,action="store_true")
     parser.add_argument(
         "--w-quant", type=str, default="NoQuantizer", choices=QUANTIZER_CLASSES.keys()
     )

--- a/utils/quartet.py
+++ b/utils/quartet.py
@@ -1,0 +1,82 @@
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.autograd import Function
+
+from .base_linear import QUANTIZER_CLASSES, NoQuantizer
+from .quartet_quantizers import StochasticRoundingQuantizer
+
+class QuartetBackwardFn(Function):
+    @staticmethod
+    def forward(ctx, x, w, g_quantizer):
+        ctx.save_for_backward(x, w)
+        ctx.g_quantizer = g_quantizer
+        return F.linear(x, w, None)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w = ctx.saved_tensors
+        gq = ctx.g_quantizer
+        if hasattr(gq, 're_randomize'):
+            gq.re_randomize()
+        grad_x = F.linear(gq(grad_output), gq(w.t().contiguous()), None)
+        batch_seq_dim = math.prod(x.shape[:-1])
+        grad_w = torch.einsum(
+            'ib,jb->ij',
+            gq(grad_output.reshape(batch_seq_dim, -1).t().contiguous()),
+            gq(x.reshape(batch_seq_dim, -1).t().contiguous()),
+        )
+        return grad_x, grad_w, None
+
+class QuartetScheme(nn.Module):
+    def __init__(self, g_quantizer=None):
+        super().__init__()
+        if g_quantizer is None:
+            g_quantizer = StochasticRoundingQuantizer()
+        self.g_quantizer = g_quantizer
+
+    def forward(self, x, w):
+        return QuartetBackwardFn.apply(x, w, self.g_quantizer)
+
+class QuartetLinear(nn.Linear):
+    def __init__(self, in_features, out_features, *, weight_quantizer=None, activation_quantizer=None, gradient_quantizer=None, bias=True, **kwargs):
+        super().__init__(in_features, out_features, bias=bias, **kwargs)
+        if weight_quantizer is None:
+            weight_quantizer = NoQuantizer()
+        if activation_quantizer is None:
+            activation_quantizer = NoQuantizer()
+        if gradient_quantizer is None:
+            gradient_quantizer = StochasticRoundingQuantizer()
+        self.weight_quantizer = weight_quantizer
+        self.activation_quantizer = activation_quantizer
+        self.backward_scheme = QuartetScheme(gradient_quantizer)
+
+    def forward(self, x):
+        xq = self.activation_quantizer(x)
+        wq = self.weight_quantizer(self.weight)
+        return self.backward_scheme(xq, wq)
+
+def prepare_model_for_quartet_training(model, args, target_module):
+    for name, module in reversed(model._modules.items()):
+        if len(list(module.children())) > 0:
+            model._modules[name] = prepare_model_for_quartet_training(module, args, target_module)
+        if isinstance(module, nn.Linear):
+            if name not in target_module:
+                continue
+            bias_data = module.bias.data if module.bias is not None else None
+            weight_data = module.weight.data
+            bias = module.bias is not None
+            new_layer = QuartetLinear(
+                module.in_features,
+                module.out_features,
+                bias=bias,
+                weight_quantizer=QUANTIZER_CLASSES[args.w_quant](**args.w_quant_kwargs),
+                activation_quantizer=QUANTIZER_CLASSES[args.a_quant](**args.a_quant_kwargs),
+                gradient_quantizer=StochasticRoundingQuantizer(bits=args.weight_bits)
+            )
+            new_layer.weight.data.copy_(weight_data)
+            if bias_data is not None:
+                new_layer.bias.data.copy_(bias_data)
+            model._modules[name] = new_layer
+    return model

--- a/utils/quartet_quantizers/__init__.py
+++ b/utils/quartet_quantizers/__init__.py
@@ -1,0 +1,1 @@
+from .sr_quantizer import StochasticRoundingQuantizer

--- a/utils/quartet_quantizers/sr_quantizer.py
+++ b/utils/quartet_quantizers/sr_quantizer.py
@@ -1,0 +1,34 @@
+import torch
+import torch.nn as nn
+from .utils_for_quant import OPTIMAL_GAUSSIAN_SCALES
+
+class StochasticRoundingQuantizer(nn.Module):
+    def __init__(self, bits=4, centered=True):
+        super().__init__()
+        self.bits = bits
+        self.centered = centered
+        self.n_levels = 2 ** bits
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        scale = OPTIMAL_GAUSSIAN_SCALES[self.bits] * torch.sqrt(torch.mean(x ** 2, dim=-1, keepdim=True)) + 1e-8
+        if self.centered:
+            step = 2 * scale / (self.n_levels - 1)
+            x_clip = torch.clamp(x, -scale, scale)
+            r = x_clip / step + 0.5
+            base = torch.floor(r)
+            prob = r - base
+            rnd = torch.rand_like(prob)
+            q = (base + (rnd < prob).float()) * step - 0.5 * step
+        else:
+            neg_scale = -scale * (self.n_levels - 2) / self.n_levels
+            step = 2 * scale / self.n_levels
+            x_clip = torch.clamp(x, neg_scale, scale)
+            r = x_clip / step
+            base = torch.floor(r)
+            prob = r - base
+            rnd = torch.rand_like(prob)
+            q = (base + (rnd < prob).float()) * step
+        return x + (q - x).detach()
+
+    def re_randomize(self):
+        pass

--- a/utils/quartet_quantizers/utils_for_quant.py
+++ b/utils/quartet_quantizers/utils_for_quant.py
@@ -1,0 +1,1 @@
+from ..base_linear import OPTIMAL_GAUSSIAN_SCALES

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -21,6 +21,7 @@ from .base_linear import (
     prepare_model_for_fp4_training_simulation_act_weight,
     prepare_model_for_quest_training_simulation_act_weight
 )
+from .quartet import prepare_model_for_quartet_training
 import bitsandbytes as bnb
 
 from .layers import ScaledLayerNorm
@@ -65,6 +66,13 @@ def setup_model(args):
         module = prepare_model_for_quest_training_simulation_act_weight(model,args,target_module)
         logger.info('--'*20)
         logger.info('Prepare Model for Activation&Weight QuESR Training')
+        logger.info('--'*20)
+    if args.quartet:
+        print('Enable Quartet quantization')
+        target_module = ['q_proj', 'k_proj', 'v_proj', 'o_proj', 'up_proj', 'down_proj', 'gate_proj']
+        module = prepare_model_for_quartet_training(model, args, target_module)
+        logger.info('--'*20)
+        logger.info('Prepare Model for Quartet Training')
         logger.info('--'*20)
     if args.act_quant:
         print('Activation-Weight Quantizing')


### PR DESCRIPTION
## Summary
- add StochasticRoundingQuantizer and quartet quantization utilities
- add `--quartet` option and model setup hook

## Testing
- `python -m py_compile utils/quartet.py utils/quartet_quantizers/sr_quantizer.py utils/argparse.py utils/setup.py`
- `python -m py_compile main_pretrain.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9d1fe7848332a41ffec9cd411627